### PR TITLE
feat(chat): 채팅 설정 저장

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
       "matches": ["https://play.afreecatv.com/*"]
     }
   ],
-  "permissions": ["activeTab", "scripting"],
+  "permissions": ["activeTab", "scripting", "storage"],
   "commands": {
     "_execute_action": {
       "suggested_key": {

--- a/src/chat-one-line.ts
+++ b/src/chat-one-line.ts
@@ -23,4 +23,10 @@ export default (node: HTMLElement) => {
 
   nicknameSection.insertBefore(wrapSpan, nickname)
   nickname.textContent = ''
+
+  const chatSection = node.querySelector('dd')
+  if (!chatSection) {
+    return
+  }
+  chatSection.style.paddingLeft = '0'
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,7 @@
+export const ID_CHAT_ONE_LINE = 'chat_one_line'
+export const ID_HIDE_GENDER_ICON = 'hide_gender_icon'
+export const ID_HIDE_DONATION = 'hide_donation'
+
+export const MESSAGE_CHAT_ONE_LINE = ID_CHAT_ONE_LINE
+export const MESSAGE_HIDE_GENDER_ICON = ID_HIDE_GENDER_ICON
+export const MESSAGE_HIDE_DONATION = ID_HIDE_DONATION

--- a/src/element-filter.ts
+++ b/src/element-filter.ts
@@ -3,7 +3,7 @@ import removeIfGender from './gender-remover'
 import displayChatOneLine from './chat-one-line'
 import setChatColor from './chat-color-setter'
 import { MESSAGE_CHAT_ONE_LINE, MESSAGE_HIDE_DONATION, MESSAGE_HIDE_GENDER_ICON } from './consts'
-import { getStorageLocal } from './storage-util'
+import { getStorageLocalBoolean } from './storage-util'
 
 // TODO: 필터링 목록 선택할 수 있도록 조정
 const targetNode = document.getElementById('chat_area')
@@ -18,9 +18,9 @@ let isRemoveIfDonation = false
 let isRemoveIfGender = false
 
 Promise.all([
-  getStorageLocal(MESSAGE_CHAT_ONE_LINE),
-  getStorageLocal(MESSAGE_HIDE_DONATION),
-  getStorageLocal(MESSAGE_HIDE_GENDER_ICON),
+  getStorageLocalBoolean(MESSAGE_CHAT_ONE_LINE),
+  getStorageLocalBoolean(MESSAGE_HIDE_DONATION),
+  getStorageLocalBoolean(MESSAGE_HIDE_GENDER_ICON),
 ])
   .then(([chatOneLineChecked, donationChecked, genderIconChecked]) => {
     isDisplayChatOneLine = chatOneLineChecked

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,6 @@
+import { ID_CHAT_ONE_LINE, ID_HIDE_DONATION, ID_HIDE_GENDER_ICON } from './consts'
+import { getStorageLocal, storageLocal } from './storage-util'
+
 const chatLayerSettingNode = document.getElementsByClassName('chat_layer_setting')?.[0]
 if (!chatLayerSettingNode) {
   throw new Error('chat_layer_setting element not found')
@@ -16,9 +19,9 @@ if (!chatLayerSubMark || !(chatLayerSubMark instanceof HTMLElement)) {
 }
 
 const items = {
-  chat_one_line: '채팅 한 줄로 보기',
-  hide_gender_icon: '성별 표시 가리기',
-  hide_donation: '별풍선 숨기기',
+  [ID_CHAT_ONE_LINE]: '채팅 한 줄로 보기',
+  [ID_HIDE_GENDER_ICON]: '성별 표시 가리기',
+  [ID_HIDE_DONATION]: '별풍선 숨기기',
 }
 
 const chatLayerSubMarkUl = chatLayerSubMark.querySelector('ul')
@@ -30,6 +33,9 @@ Object.entries(items).forEach(([id, text]) => {
   const checkbox = document.createElement('input')
   checkbox.type = 'checkbox'
   checkbox.id = id
+  getStorageLocal(id).then((checked) => {
+    checkbox.checked = checked
+  })
 
   const label = document.createElement('label')
   label.htmlFor = id
@@ -39,5 +45,12 @@ Object.entries(items).forEach(([id, text]) => {
   div.appendChild(label)
 
   checkboxItem.appendChild(div)
+  checkboxItem.addEventListener('change', onSettingChange)
   chatLayerSubMarkUl?.appendChild(checkboxItem)
 })
+
+function onSettingChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  const { id, checked } = target
+  storageLocal({ key: id, value: checked })
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { ID_CHAT_ONE_LINE, ID_HIDE_DONATION, ID_HIDE_GENDER_ICON } from './consts'
-import { getStorageLocal, storageLocal } from './storage-util'
+import { getStorageLocal, storageLocalBoolean } from './storage-util'
 
 const chatLayerSettingNode = document.getElementsByClassName('chat_layer_setting')?.[0]
 if (!chatLayerSettingNode) {
@@ -52,5 +52,5 @@ Object.entries(items).forEach(([id, text]) => {
 function onSettingChange(event: Event) {
   const target = event.target as HTMLInputElement
   const { id, checked } = target
-  storageLocal({ key: id, value: checked })
+  storageLocalBoolean({ key: id, value: checked })
 }

--- a/src/storage-util.ts
+++ b/src/storage-util.ts
@@ -1,0 +1,14 @@
+export async function getStorageLocal(key: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    chrome.storage.local.get(key, (result) => {
+      if (!result[key]) {
+        return resolve(false)
+      }
+      return resolve(result[key])
+    })
+  })
+}
+
+export function storageLocal({ key, value }: { key: string; value: boolean }) {
+  return chrome.storage.local.set({ [key]: value })
+}

--- a/src/storage-util.ts
+++ b/src/storage-util.ts
@@ -1,14 +1,15 @@
-export async function getStorageLocal(key: string): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
+export async function getStorageLocal<T = any>(key: string): Promise<T> {
+  return new Promise<T>((resolve) => {
     chrome.storage.local.get(key, (result) => {
-      if (!result[key]) {
-        return resolve(false)
-      }
       return resolve(result[key])
     })
   })
 }
 
-export function storageLocal({ key, value }: { key: string; value: boolean }) {
+export async function getStorageLocalBoolean(key: string): Promise<boolean> {
+  return getStorageLocal<boolean>(key)
+}
+
+export function storageLocalBoolean({ key, value }: { key: string; value: boolean }) {
   return chrome.storage.local.set({ [key]: value })
 }


### PR DESCRIPTION
## Feature Description

- feat(chat): 채팅 설정 저장
- feat(common): storage util
- fix(chat): one line이면서 성별 아이콘 가리지 않았을 때 padding 적용되는 문제

![image](https://github.com/Zabee52/Twiraforming/assets/93498724/4acce177-0c65-4636-87cd-c55f19c7720f)


## Solution Description

- `manifest.json`: storage 권한 부여
- `consts.ts`: `element-filter.ts`에서 사용하기 위해 상수 분리
- `element-filter.ts`: storage 상태에 따른 채팅창 설정 반영
- `settings.ts`: 설정 저장
- `chat-one-line.ts`: one line이면서 성별 아이콘 가리지 않았을 때 padding 적용되는 문제 수정

## Types of changes

- [x] New feature
- [x] Bug fix