### PR TITLE
fix(common): remove tabs permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
       "matches": ["https://play.afreecatv.com/*"]
     }
   ],
-  "permissions": ["tabs", "storage"],
+  "permissions": ["storage"],
   "background": {
     "service_worker": "dist/background.bundle.js"
   }


### PR DESCRIPTION
## Feature Description

- fix(common): remove tabs permission
- 탭 열때 `chrome.tabs.create()` 사용하길래 tabs 권한 필요한 줄 알았는데 없어도 되는거였기 때문에.. 😅

## Types of changes

- [x] Bug fix