### PR TITLE
modify(chat): 사용자 닉네임 색상 적당하게 조절

### DIFF
--- a/src/lib/chat-color-setter.ts
+++ b/src/lib/chat-color-setter.ts
@@ -1,9 +1,11 @@
+import { getBrightnessAdjustedHex } from './color-utils'
+
 export default (node: HTMLElement) => {
   if (!node?.hasAttribute('user_id')) {
     return
   }
-  const userIdNumber = stringToNumber(node.getAttribute('user_id'))
-  const nicknameColor = '#' + (userIdNumber % 0xffffff).toString(16).padStart(6, '0')
+  const userIdHex = userIdToHex(node.getAttribute('user_id') || '000000')
+  const nicknameColor = '#' + getBrightnessAdjustedHex(userIdHex)
 
   const nicknameSection = node.querySelector('dt')?.querySelector('a')
   if (!nicknameSection) {
@@ -25,4 +27,13 @@ function stringToNumber(str: string | null) {
     result += str.charCodeAt(i)
   }
   return parseInt(result)
+}
+
+function numberToHex(number: number) {
+  return number.toString(16).padStart(6, '0')
+}
+
+function userIdToHex(userId: string) {
+  const userIdNumber = stringToNumber(userId)
+  return numberToHex(userIdNumber)
 }

--- a/src/lib/chat-one-line.ts
+++ b/src/lib/chat-one-line.ts
@@ -20,6 +20,7 @@ export default (node: HTMLElement) => {
     return
   }
   // 닉네임에 bold 적용
+  // em 태그로 생성하는 이유는 기존 afreecaTV의 스타일을 상속받기 위해
   const wrapEm = document.createElement('em')
   wrapEm.textContent = nickname.textContent
   wrapEm.style.fontWeight = 'bold'
@@ -32,6 +33,7 @@ export default (node: HTMLElement) => {
   const chatSectionSpan = elementToSpan(chatSection)
   chatSectionSpan.style.fontFamily = '"NG", "돋움", "dotum", "AppleGothic"'
   chatSectionSpan.style.fontSize = 'calc( var(--text-default) + var(--text-size) * 2 )'
+  chatSectionSpan.style.marginLeft = '2px'
   for (const className of node.classList ?? []) {
     if (className !== 'bj') {
       continue

--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,0 +1,51 @@
+import { Rgb } from './interfaces'
+
+function hexToRgb(hex: string): Rgb {
+  const bigint = parseInt(hex, 16) % 0xffffff // Adjust hex to 6 digits
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+
+  return { r, g, b }
+}
+
+function getBrightness(rgb: Rgb) {
+  return Math.round((rgb.r * 299 + rgb.g * 587 + rgb.b * 114) / 1000)
+}
+
+// 밝기가 150보다 높으면 어둡게, 100보다 낮으면 밝게 조정
+function adjustRgbBrightness(rgb: Rgb) {
+  const brightness = getBrightness(rgb)
+  const brightCriteria = 150
+  const darkCriteria = 100
+  const tooBright = brightness > brightCriteria
+  const tooDark = brightness < darkCriteria
+  if (!tooBright && !tooDark) {
+    return rgb
+  }
+
+  let factor = 1
+  if (tooBright) {
+    factor = brightCriteria / (brightness || 1)
+  } else if (tooDark) {
+    factor = darkCriteria / (brightness || 1)
+  }
+  return {
+    r: Math.min(255, Math.round(rgb.r * factor)),
+    g: Math.min(255, Math.round(rgb.g * factor)),
+    b: Math.min(255, Math.round(rgb.b * factor)),
+  }
+}
+
+function rgbToHex(rgb: Rgb) {
+  const r = rgb.r.toString(16).padStart(2, '0')
+  const g = rgb.g.toString(16).padStart(2, '0')
+  const b = rgb.b.toString(16).padStart(2, '0')
+  return r + g + b
+}
+
+export function getBrightnessAdjustedHex(hex: string) {
+  const rgb = hexToRgb(hex)
+  const adjustedRgb = adjustRgbBrightness(rgb)
+  return rgbToHex(adjustedRgb)
+}

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -1,0 +1,11 @@
+export interface SettingItem {
+  text: string
+  noticeOn: string
+  noticeOff: string
+}
+
+export interface Rgb {
+  r: number
+  g: number
+  b: number
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,5 @@
 import { ID_CHAT_ONE_LINE, ID_HIDE_DONATION, ID_HIDE_GENDER_ICON } from './lib/consts'
+import { SettingItem } from './lib/interfaces'
 import { getStorageLocal, storageLocalBoolean } from './lib/storage-utils'
 
 const chatLayerSettingNode = document.getElementsByClassName('chat_layer_setting')?.[0]
@@ -18,11 +19,6 @@ if (!chatLayerSubMark || !(chatLayerSubMark instanceof HTMLElement)) {
   throw new Error('chat_layer sub mark element not found')
 }
 
-interface SettingItem {
-  text: string
-  noticeOn: string
-  noticeOff: string
-}
 const items: Record<string, SettingItem>= {
   [ID_CHAT_ONE_LINE]: {
     text: '채팅 한 줄로 보기',


### PR DESCRIPTION
## Feature Description

- modify(chat): 사용자 닉네임 색상 적당하게 조절
- refactor(common): interface to interfaces.ts
- 현재는 밝기 범위를 100 < x < 150 으로 지정.
- 밝기 공식 : `red * 0.29 + green * 0.587 + blue * 0.114`

## Solution Description

- `interfaces.ts`: Created
- `chat-color-setter.ts`: 조정된 hex color를 적용
- `chat-one-line.ts`: 채팅 섹션에 `margin-left: 2px;` 적용 (가시성을 위해)
- `color-utils.ts`: 밝기 조정를 위한 method 추가

## Types of changes

- [x] Modify 
- [x] Refactoring