### PR TITLE
feat(chat): 닉네임 색상 변경 활성화 기능

### DIFF
--- a/src/element-filter.ts
+++ b/src/element-filter.ts
@@ -2,7 +2,12 @@ import removeIfDonation from './lib/donation-remover'
 import removeIfGender from './lib/gender-remover'
 import displayChatOneLine from './lib/chat-one-line'
 import setChatColor from './lib/chat-color-setter'
-import { MESSAGE_CHAT_ONE_LINE, MESSAGE_HIDE_DONATION, MESSAGE_HIDE_GENDER_ICON } from './lib/consts'
+import {
+  MESSAGE_CHAT_ONE_LINE,
+  MESSAGE_HIDE_DONATION,
+  MESSAGE_HIDE_GENDER_ICON,
+  MESSAGE_SET_NICKNAME_COLOR,
+} from './lib/consts'
 import { getStorageLocalBoolean } from './lib/storage-utils'
 
 // TODO: 필터링 목록 선택할 수 있도록 조정
@@ -14,6 +19,7 @@ if (!targetNode) {
 const observerConfig = { attributes: false, childList: true, subtree: true }
 
 let isDisplayChatOneLine = false
+let isSetNicknameColor = false
 let isRemoveIfDonation = false
 let isRemoveIfGender = false
 
@@ -21,11 +27,13 @@ Promise.all([
   getStorageLocalBoolean(MESSAGE_CHAT_ONE_LINE),
   getStorageLocalBoolean(MESSAGE_HIDE_DONATION),
   getStorageLocalBoolean(MESSAGE_HIDE_GENDER_ICON),
+  getStorageLocalBoolean(MESSAGE_SET_NICKNAME_COLOR),
 ])
-  .then(([chatOneLineChecked, donationChecked, genderIconChecked]) => {
+  .then(([chatOneLineChecked, donationChecked, genderIconChecked, setNicknameColorChecked]) => {
     isDisplayChatOneLine = chatOneLineChecked
     isRemoveIfDonation = donationChecked
     isRemoveIfGender = genderIconChecked
+    isSetNicknameColor = setNicknameColorChecked
   })
   .catch((error) => {
     console.error('😞 스토리지에서 설정을 불러오는 데 실패했습니다:', error)
@@ -38,16 +46,10 @@ const callback = function (mutationsList: MutationRecord[], observer: MutationOb
         if (!(node instanceof HTMLElement)) {
           return
         }
-        if (isRemoveIfDonation) {
-          removeIfDonation(node)
-        }
-        if (isRemoveIfGender) {
-          removeIfGender(node)
-        }
-        if (isDisplayChatOneLine) {
-          displayChatOneLine(node)
-          setChatColor(node)
-        }
+        isRemoveIfDonation && removeIfDonation(node)
+        isRemoveIfGender && removeIfGender(node)
+        isDisplayChatOneLine && displayChatOneLine(node)
+        isSetNicknameColor && setChatColor(node)
       })
     }
   }
@@ -66,6 +68,9 @@ chrome.storage.onChanged.addListener(function (changes, areaName) {
   }
   if (changes[MESSAGE_CHAT_ONE_LINE]) {
     isDisplayChatOneLine = changes[MESSAGE_CHAT_ONE_LINE].newValue
+  }
+  if (changes[MESSAGE_SET_NICKNAME_COLOR]) {
+    isSetNicknameColor = changes[MESSAGE_SET_NICKNAME_COLOR].newValue
   }
   if (changes[MESSAGE_HIDE_DONATION]) {
     isRemoveIfDonation = changes[MESSAGE_HIDE_DONATION].newValue

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,7 +1,9 @@
 export const ID_CHAT_ONE_LINE = 'chat_one_line'
+export const ID_SET_NICKNAME_COLOR = 'set_nickname_color'
 export const ID_HIDE_GENDER_ICON = 'hide_gender_icon'
 export const ID_HIDE_DONATION = 'hide_donation'
 
 export const MESSAGE_CHAT_ONE_LINE = ID_CHAT_ONE_LINE
+export const MESSAGE_SET_NICKNAME_COLOR = ID_SET_NICKNAME_COLOR
 export const MESSAGE_HIDE_GENDER_ICON = ID_HIDE_GENDER_ICON
 export const MESSAGE_HIDE_DONATION = ID_HIDE_DONATION

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { ID_CHAT_ONE_LINE, ID_HIDE_DONATION, ID_HIDE_GENDER_ICON } from './lib/consts'
+import { ID_CHAT_ONE_LINE, ID_HIDE_DONATION, ID_HIDE_GENDER_ICON, ID_SET_NICKNAME_COLOR } from './lib/consts'
 import { SettingItem } from './lib/interfaces'
 import { getStorageLocal, storageLocalBoolean } from './lib/storage-utils'
 
@@ -24,6 +24,11 @@ const items: Record<string, SettingItem>= {
     text: '채팅 한 줄로 보기',
     noticeOn: '지금부터 채팅이 한 줄로 표시됩니다.',
     noticeOff: '지금부터 채팅이 여러 줄로 표시됩니다.',
+  },
+  [ID_SET_NICKNAME_COLOR]: {
+    text: '닉네임에 랜덤 색상 적용',
+    noticeOn: '지금부터 닉네임에 색상이 적용됩니다.',
+    noticeOff: '지금부터 닉네임에 색상이 적용되지 않습니다.',
   },
   [ID_HIDE_GENDER_ICON]: {
     text: '성별 표시 가리기',


### PR DESCRIPTION
## Feature Description

- feat(chat): 닉네임 색상 변경 활성화 기능
- 비활성화 시 아래와 같이, 활성화 시 랜덤한 색상 적용
![image](https://github.com/Zabee52/Wakfreeca/assets/93498724/85420bb5-a217-445d-8daa-9db6636e8b3c)


## Solution Description

- `element-filter.ts`: storage에서 닉네임 색상 설정 관련 storage에서 받아오도록 수정
- `consts.ts`: 닉네임 색상 설정 관련 상수 추가
- `settings.ts`: 닉네임 색상 설정 관련 UI 추가

## Types of changes

- [x] New feature