### PR TITLE
feat(chat): 별풍선/구독, 애드벌룬, 스티커 감추기 기능

### DIFF
--- a/src/element-filter.ts
+++ b/src/element-filter.ts
@@ -1,10 +1,10 @@
-import removeIfDonation from './lib/donation-remover'
+import displayDonation from './lib/display-donation'
 import displayChatOneLine from './lib/chat-one-line'
-import setChatColor from './lib/chat-color-setter'
-import { MESSAGE_CHAT_ONE_LINE, MESSAGE_HIDE_DONATION, MESSAGE_SET_NICKNAME_COLOR } from './lib/consts'
-import { getStorageLocalBoolean } from './lib/storage-utils'
 import displayPersonacon from './lib/display-personacon'
 import displayIcon from './lib/display-icon'
+import setChatColor from './lib/chat-color-setter'
+import { MESSAGE_CHAT_ONE_LINE, MESSAGE_SET_NICKNAME_COLOR } from './lib/consts'
+import { getStorageLocalBoolean } from './lib/storage-utils'
 
 // TODO: 필터링 목록 선택할 수 있도록 조정
 const targetNode = document.getElementById('chat_area')
@@ -16,16 +16,10 @@ const observerConfig = { attributes: false, childList: true, subtree: true }
 
 let isDisplayChatOneLine = false
 let isSetNicknameColor = false
-let isRemoveIfDonation = false
 
-Promise.all([
-  getStorageLocalBoolean(MESSAGE_CHAT_ONE_LINE),
-  getStorageLocalBoolean(MESSAGE_HIDE_DONATION),
-  getStorageLocalBoolean(MESSAGE_SET_NICKNAME_COLOR),
-])
-  .then(([chatOneLineChecked, donationChecked, setNicknameColorChecked]) => {
+Promise.all([getStorageLocalBoolean(MESSAGE_CHAT_ONE_LINE), getStorageLocalBoolean(MESSAGE_SET_NICKNAME_COLOR)])
+  .then(([chatOneLineChecked, setNicknameColorChecked]) => {
     isDisplayChatOneLine = chatOneLineChecked
-    isRemoveIfDonation = donationChecked
     isSetNicknameColor = setNicknameColorChecked
   })
   .catch((error) => {
@@ -39,7 +33,7 @@ const callback = function (mutationsList: MutationRecord[], observer: MutationOb
         if (!(node instanceof HTMLElement)) {
           return
         }
-        isRemoveIfDonation && removeIfDonation(node)
+        displayDonation(node)
         displayPersonacon(node)
         displayIcon(node)
         isDisplayChatOneLine && displayChatOneLine(node)
@@ -65,8 +59,5 @@ chrome.storage.onChanged.addListener(function (changes, areaName) {
   }
   if (changes[MESSAGE_SET_NICKNAME_COLOR]) {
     isSetNicknameColor = changes[MESSAGE_SET_NICKNAME_COLOR].newValue
-  }
-  if (changes[MESSAGE_HIDE_DONATION]) {
-    isRemoveIfDonation = changes[MESSAGE_HIDE_DONATION].newValue
   }
 })

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,11 +1,9 @@
 // Checkbox items
 export const ID_CHAT_ONE_LINE = 'chat_one_line'
 export const ID_SET_NICKNAME_COLOR = 'set_nickname_color'
-export const ID_HIDE_DONATION = 'hide_donation'
 
 export const MESSAGE_CHAT_ONE_LINE = ID_CHAT_ONE_LINE
 export const MESSAGE_SET_NICKNAME_COLOR = ID_SET_NICKNAME_COLOR
-export const MESSAGE_HIDE_DONATION = ID_HIDE_DONATION
 
 // Chat layer items
 export const ID_CHAT_LAYER_SET_DISPLAY_PERSONACON = 'chat_layer_set_personacon'
@@ -16,12 +14,12 @@ export const MESSAGE_CHAT_LAYER_SET_DISPLAY_ICON = ID_CHAT_LAYER_SET_DISPLAY_ICO
 export const MESSAGE_CHAT_LAYER_SET_DISPLAY_DONATION = ID_CHAT_LAYER_SET_DISPLAY_DONATION
 
 // Chat layer set display icon items
-export const ID_PERSONACON_BJ = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_bj')
-export const ID_PERSONACON_MANAGER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_manager')
-export const ID_PERSONACON_FEVER_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_fever_fan')
-export const ID_PERSONACON_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_fan')
-export const ID_PERSONACON_NORMAL = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_normal')
-export const ID_PERSONACON_SUBSCRIPTION = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'personacon_subscription')
+export const ID_PERSONACON_BJ = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'bj')
+export const ID_PERSONACON_MANAGER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'manager')
+export const ID_PERSONACON_FEVER_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'fever_fan')
+export const ID_PERSONACON_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'fan')
+export const ID_PERSONACON_NORMAL = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'normal')
+export const ID_PERSONACON_SUBSCRIPTION = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_PERSONACON, 'subscription')
 
 export const CHAT_LAYER_SET_DISPLAY_PERSONACON_MESSAGES = [
   ID_PERSONACON_BJ,
@@ -32,12 +30,13 @@ export const CHAT_LAYER_SET_DISPLAY_PERSONACON_MESSAGES = [
   ID_PERSONACON_SUBSCRIPTION,
 ]
 
-export const ID_ICON_BJ = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_bj')
-export const ID_ICON_MANAGER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_manager')
-export const ID_ICON_SUBSCRIPTION = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_subscription')
-export const ID_ICON_FEVER_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_fever_fan')
-export const ID_ICON_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_fan')
-export const ID_ICON_QUICK_VIEW = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'icon_quick_view')
+export const ID_ICON_BJ = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'bj')
+export const ID_ICON_MANAGER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'manager')
+export const ID_ICON_SUBSCRIPTION = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'subscription')
+export const ID_ICON_FEVER_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'fever_fan')
+export const ID_ICON_FAN = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'fan')
+export const ID_ICON_SUPPORTER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'supporter')
+export const ID_ICON_QUICK_VIEW = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_ICON, 'quick_view')
 
 export const CHAT_LAYER_SET_DISPLAY_ICON_MESSAGES = [
   ID_ICON_BJ,
@@ -45,13 +44,16 @@ export const CHAT_LAYER_SET_DISPLAY_ICON_MESSAGES = [
   ID_ICON_SUBSCRIPTION,
   ID_ICON_FEVER_FAN,
   ID_ICON_FAN,
+  ID_ICON_SUPPORTER,
   ID_ICON_QUICK_VIEW,
 ]
 
 // Chat layer set display donation items
-export const ID_DONATION_BALOON = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_DONATION, 'baloon')
-export const ID_DONATION_AD_BALOON = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_DONATION, 'adbaloon')
+export const ID_DONATION_BALLOON = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_DONATION, 'balloon')
+export const ID_DONATION_AD_BALLOON = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_DONATION, 'adballoon')
 export const ID_DONATION_STICKER = withPrefix(ID_CHAT_LAYER_SET_DISPLAY_DONATION, 'sticker')
+
+export const CHAT_LAYER_SET_DISPLAY_DONATION_MESSAGES = [ID_DONATION_BALLOON, ID_DONATION_AD_BALLOON, ID_DONATION_STICKER]
 
 function withPrefix(prefix: string, str: string) {
   return `${prefix}_${str}`

--- a/src/lib/display-donation.ts
+++ b/src/lib/display-donation.ts
@@ -1,0 +1,52 @@
+import {
+  CHAT_LAYER_SET_DISPLAY_DONATION_MESSAGES,
+  ID_DONATION_BALLOON,
+  ID_DONATION_AD_BALLOON,
+  ID_DONATION_STICKER,
+} from './consts'
+import { getStorageLocalBoolean } from './storage-utils'
+
+const donationDisplayMap: Record<string, boolean> = {}
+CHAT_LAYER_SET_DISPLAY_DONATION_MESSAGES.forEach((message) => {
+  getStorageLocalBoolean(message, true).then((value) => {
+    donationDisplayMap[message] = value
+  })
+})
+
+export default (node: HTMLElement) => {
+  if (!node?.classList?.length) {
+    return
+  }
+
+  let needRemove = false
+
+  const isBalloon = ['balloon_area', 'fanclub'].some((className) => node.classList.contains(className))
+  if (isBalloon && !donationDisplayMap[ID_DONATION_BALLOON]) {
+    needRemove = true
+  }
+  const isAdballon = ['adballoon_area', 'fanclub'].some((className) => node.classList.contains(className))
+  if (isAdballon && !donationDisplayMap[ID_DONATION_AD_BALLOON]) {
+    needRemove = true
+  }
+  const isSticker = ['sticker_area', 'support'].some((className) => node.classList.contains(className))
+  if (isSticker && !donationDisplayMap[ID_DONATION_STICKER]) {
+    needRemove = true
+  }
+
+  if (needRemove) {
+    node.remove()
+  }
+}
+
+// Storage Change Listener
+chrome.storage.onChanged.addListener(function (changes, areaName) {
+  if (areaName !== 'local') {
+    return
+  }
+  CHAT_LAYER_SET_DISPLAY_DONATION_MESSAGES.forEach((message) => {
+    if (!changes[message]) {
+      return
+    }
+    donationDisplayMap[message] = changes[message].newValue
+  })
+})

--- a/src/lib/display-icon.ts
+++ b/src/lib/display-icon.ts
@@ -6,6 +6,7 @@ import {
   ID_ICON_FEVER_FAN,
   ID_ICON_FAN,
   ID_ICON_QUICK_VIEW,
+  ID_ICON_SUPPORTER,
 } from './consts'
 import { getStorageLocalBoolean } from './storage-utils'
 
@@ -51,6 +52,11 @@ export default (node: HTMLElement) => {
   const subscriberImage = icons.find((icon) => icon.title === '구독팬')
   if (subscriberImage && !iconDisplayMap[ID_ICON_SUBSCRIPTION]) {
     subscriberImage.remove()
+  }
+
+  const supporterImage = icons.find((icon) => icon.title === '서포터')
+  if (supporterImage && !iconDisplayMap[ID_ICON_SUPPORTER]) {
+    supporterImage.remove()
   }
 }
 

--- a/src/lib/donation-remover.ts
+++ b/src/lib/donation-remover.ts
@@ -1,9 +1,0 @@
-export default (node: HTMLElement) => {
-  if (!node?.classList) {
-    return
-  }
-  const removeTargetClassNames = ['balloon_area', 'adballoon_area', 'fanclub']
-  if (removeTargetClassNames.some((className) => node.classList.contains(className))) {
-    node.remove()
-  }
-}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,10 @@ import {
   ID_CHAT_LAYER_SET_DISPLAY_PERSONACON,
   ID_PERSONACON_FAN,
   ID_PERSONACON_FEVER_FAN,
+  ID_DONATION_AD_BALLOON,
+  ID_DONATION_BALLOON,
+  ID_DONATION_STICKER,
+  ID_ICON_SUPPORTER,
 } from './lib/consts'
 import { SettingItem } from './lib/interfaces'
 import { getStorageLocalBoolean, storageLocalBoolean } from './lib/storage-utils'
@@ -36,7 +40,7 @@ const chatLayerSetPersonaconItems: Record<string, SettingItem> = {
   },
   [ID_PERSONACON_SUBSCRIPTION]: {
     type: 'checkbox',
-    text: '구독 퍼스나콘',
+    text: '구독자 퍼스나콘',
   },
   [ID_PERSONACON_FEVER_FAN]: {
     type: 'checkbox',
@@ -63,7 +67,7 @@ const chatLayerSetIconItems: Record<string, SettingItem> = {
   },
   [ID_ICON_SUBSCRIPTION]: {
     type: 'checkbox',
-    text: '구독 아이콘',
+    text: '구독자 아이콘',
   },
   [ID_ICON_FEVER_FAN]: {
     type: 'checkbox',
@@ -73,6 +77,10 @@ const chatLayerSetIconItems: Record<string, SettingItem> = {
     type: 'checkbox',
     text: '팬클럽 아이콘',
   },
+  [ID_ICON_SUPPORTER]: {
+    type: 'checkbox',
+    text: '서포터 아이콘',
+  },
   [ID_ICON_QUICK_VIEW]: {
     type: 'checkbox',
     text: '퀵뷰 아이콘',
@@ -80,21 +88,17 @@ const chatLayerSetIconItems: Record<string, SettingItem> = {
 }
 
 const chatLayerSetDisplayDonationItems: Record<string, SettingItem> = {
-  baloon: {
+  [ID_DONATION_BALLOON]: {
     type: 'checkbox',
-    text: '별풍선',
+    text: '별풍선 / 구독',
   },
-  adBaloon: {
+  [ID_DONATION_AD_BALLOON]: {
     type: 'checkbox',
     text: '애드벌룬',
   },
-  sticker: {
+  [ID_DONATION_STICKER]: {
     type: 'checkbox',
     text: '스티커',
-  },
-  chocolate: {
-    type: 'checkbox',
-    text: '초콜릿',
   },
 }
 
@@ -203,6 +207,17 @@ function onAreaHeaderClick(event: Event, prevNode: HTMLElement) {
   chatLayer?.classList?.toggle('on')
 }
 
+function onCloseButtonClick(event: Event) {
+  const target = event.target as HTMLElement
+  const close = target.classList.contains('close')
+  if (!close) {
+    return
+  }
+
+  const chatLayer = target.closest('.chat_layer')
+  chatLayer?.classList?.toggle('on')
+}
+
 function createChatLayer(id: string, title: string, prevNode: HTMLElement) {
   const areaHeader = document.createElement('div')
   areaHeader.classList.add('area_header')
@@ -226,12 +241,19 @@ function createChatLayer(id: string, title: string, prevNode: HTMLElement) {
   const contentsUl = document.createElement('ul')
   contents.appendChild(contentsUl)
 
+  const closeBtn = document.createElement('a')
+  closeBtn.href = 'javascript:;'
+  closeBtn.classList.add('close')
+  closeBtn.innerText = '닫기'
+  closeBtn.addEventListener('click', (event: Event) => onCloseButtonClick(event))
+
   const chatLayer = document.createElement('div')
   chatLayer.classList.add('chat_layer')
   chatLayer.classList.add('sub')
   chatLayer.classList.add(id)
   chatLayer.appendChild(areaHeader)
   chatLayer.appendChild(contents)
+  chatLayer.appendChild(closeBtn)
   return chatLayer
 }
 


### PR DESCRIPTION
## Feature Description

- feat(chat): 별풍선/구독, 애드벌룬, 스티커 감추기 기능
- feat(chat): 서포터 아이콘 관련 UI
- chore(chat): Remove simple donation remover
- 구독도 별도로 카테고리 분류하고 싶은데, 구독이 기술적으로 별풍선과 같은 area에서 처리되는 문제가 있었음 😞

## Solution Description

- `element-filter.ts`: 후원 상세 설정 관련 기능 추가, `donation-remover.ts`관련 기능 제거
- `consts.ts`: 서포터 관련 변수 추가, 변수 이름 조정
- `display-donation.ts`: 별풍선/구독, 애드벌룬, 스티커 감추기 기능
- `display-icon.ts`: 서포터 아이콘 감추기 관련 기능
- `donation-remover.ts`: Removed
- `settings.ts`: 별풍선/구독, 애드벌룬, 스티커 감추기 기능 변수 정의, `chat_layer`에 닫기 버튼 추가, 서포터 아이콘 표시 관련 UI

## Types of changes

- [x] New feature
- [x] Chore