### PR TITLE
fix(chat): 설정 변경 메세지 아래에서 고정되는 문제

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -334,5 +334,7 @@ function noticeSettingChanged(msg: string) {
   if (!chatArea) {
     return
   }
-  chatArea.appendChild(noticeP)
+  // 채팅창이 얼어있을 경우 .box_ice element 아래에 채팅 및 알림이 추가되며, 그렇지 않을 경우 .chat_area element 아래에 추가됨
+  const icedArea = chatArea.querySelector('.box_ice:last-child')
+  !!icedArea ? icedArea.appendChild(noticeP) : chatArea.appendChild(noticeP)
 }


### PR DESCRIPTION
## Feature Description

- fix(chat): 설정 변경 메세지 아래에서 고정되는 문제
- 원인은 얼린 상태와 일반 채팅창이 별도의 Element에서 관리되고 있다는 점이었음.

## Solution Description

- `settings.ts`: 설정 변경 알림 할 때 표시되는 영역 채팅창 얼었는지 여부로 분기하도록 적용

## Types of changes

- [x] Bug fix