### PR TITLE
fix(chat): 팬 컬러 채팅은 한 줄로 보기가 적용되지 않는 문제

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Wakfreeca",
   "description": "UI utility for afreecatv",
-  "version": "1.2.0",
+  "version": "1.1.3",
   "action": {
     "default_icon": {
       "16": "images/icon-16.png",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "AfreecaTV에서 사용할 유틸리티",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack"
   },
   "repository": {
     "type": "git",

--- a/src/lib/afreeca-utils.ts
+++ b/src/lib/afreeca-utils.ts
@@ -1,0 +1,3 @@
+export function isBj(element: HTMLElement) {
+  return element.classList.contains('bj')
+}

--- a/src/lib/chat-color-setter.ts
+++ b/src/lib/chat-color-setter.ts
@@ -1,6 +1,11 @@
+import { isBj } from './afreeca-utils'
 import { getBrightnessAdjustedHex } from './color-utils'
 
 export default (node: HTMLElement) => {
+  if (isBj(node)) {
+    return
+  }
+
   const userIdHex = userIdToHex(node.getAttribute('user_id') || '000000')
   const nicknameColor = '#' + getBrightnessAdjustedHex(userIdHex)
 

--- a/src/lib/chat-one-line.ts
+++ b/src/lib/chat-one-line.ts
@@ -1,3 +1,4 @@
+import { isBj } from './afreeca-utils'
 import { cloneElementColorStyle, elementToSpan } from './dom-utils'
 
 export default (node: HTMLElement) => {
@@ -31,13 +32,11 @@ export default (node: HTMLElement) => {
   chatSectionSpan.style.fontFamily = '"NG", "돋움", "dotum", "AppleGothic"'
   chatSectionSpan.style.fontSize = 'calc( var(--text-default) + var(--text-size) * 2 )'
   chatSectionSpan.style.marginLeft = '2px'
-  for (const className of node.classList ?? []) {
-    if (className !== 'bj') {
-      continue
-    }
+
+  if (isBj(node)) {
     chatSectionSpan.style.fontWeight = 'bold'
-    break
   }
+
   chatSection.replaceWith(chatSectionSpan)
 }
 

--- a/src/lib/chat-one-line.ts
+++ b/src/lib/chat-one-line.ts
@@ -1,4 +1,4 @@
-import { elementToSpan } from './dom-utils'
+import { cloneElementColorStyle, elementToSpan } from './dom-utils'
 
 export default (node: HTMLElement) => {
   node.style.paddingTop = '2px'
@@ -27,7 +27,7 @@ export default (node: HTMLElement) => {
   if (!chatSection) {
     return
   }
-  const chatSectionSpan = elementToSpan(chatSection)
+  const chatSectionSpan = chatToSpanIfFanChat(chatSection)
   chatSectionSpan.style.fontFamily = '"NG", "돋움", "dotum", "AppleGothic"'
   chatSectionSpan.style.fontSize = 'calc( var(--text-default) + var(--text-size) * 2 )'
   chatSectionSpan.style.marginLeft = '2px'
@@ -39,4 +39,14 @@ export default (node: HTMLElement) => {
     break
   }
   chatSection.replaceWith(chatSectionSpan)
+}
+
+function chatToSpanIfFanChat(element: HTMLElement) {
+  const fanChatColorElement = element.querySelector('#fan_chatcolor') as HTMLElement | null
+  if (!fanChatColorElement) {
+    return elementToSpan(element)
+  }
+  const chatSpan = elementToSpan(fanChatColorElement)
+  cloneElementColorStyle(fanChatColorElement, chatSpan)
+  return chatSpan
 }

--- a/src/lib/dom-utils.ts
+++ b/src/lib/dom-utils.ts
@@ -3,8 +3,21 @@ export function elementToSpan(element: HTMLElement) {
   while (element.firstChild) {
     span.appendChild(element.firstChild)
   }
-  element.classList?.forEach((className) => {
-    span.classList.add(className)
-  })
+  cloneElementClass(element, span)
+
   return span
+}
+
+function cloneElementClass(element: HTMLElement, target: HTMLElement) {
+  element.classList?.forEach((className) => {
+    target.classList.add(className)
+  })
+}
+
+export function cloneElementColorStyle(element: HTMLElement, target: HTMLElement) {
+  const styles = window.getComputedStyle(element)
+  const colorStyle = styles.getPropertyValue('color')
+  if (colorStyle) {
+    target.style.color = colorStyle
+  }
 }

--- a/src/move-layer.ts
+++ b/src/move-layer.ts
@@ -107,4 +107,4 @@ function init() {
   moveLayerRoot.appendChild(userFilteredChatPopup)
 }
 
-init()
+// init()


### PR DESCRIPTION
## Feature Description

- fix(chat): 팬 컬러 채팅은 한 줄로 보기가 적용되지 않는 문제
  - 칼라챗은 `#fan_chatcolor` 속성을 가진 div로 별도로 생성되고 있었음. 대체 왜..? 🫠
- modify(chat): BJ는 닉네임 색상 변경되지 않도록 변경

## Solution Description

- `manifest.json`: version 1.2.0 -> 1.1.3 for fix bug
- `afreeca-utils.ts`: bj class 있는지 확인하는 util method `isBj()` 추가
- `chat-color-setter.ts`: bj일 경우 닉네임 색상 변경하지 않도록 변경
- `move-layer.ts`: 버전 올리기 전에 잠시 감추기
- `chat-one-line.ts`: 챗의 하위 element가 #fan_chatcolor id 보유중 일 경우 style 상속받아 span으로 전환하는 method `chatToSpanIfFanChat()` 추가
- `dom-util.ts`: clone element class refactor, 스타일 복제하는 method `cloneElementColorStyle()` 추가

## Types of changes

- [x] Bug fix