### PR TITLE
fix(chat): 퍼스나콘 사용 시 채팅 사이에 공백이 생기는 문제

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Wakfreeca",
   "description": "UI utility for afreecatv",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "action": {
     "default_icon": {
       "16": "images/icon-16.png",

--- a/src/lib/chat-one-line.ts
+++ b/src/lib/chat-one-line.ts
@@ -29,6 +29,7 @@ export default (node: HTMLElement) => {
   chat.style.display = 'inline'
   chat.style.marginLeft = '4px'
   chat.style.lineHeight = '1.5'
+  chat.style.paddingLeft = '0' // 퍼스나콘 사용 시 적용되는 왼쪽 패딩 제거 목적
 
   // 팬 채팅일 경우 처리
   // 팬 채팅은 chat element 하위에 fan_chatcolor div element가 있음.

--- a/src/lib/display-personacon.ts
+++ b/src/lib/display-personacon.ts
@@ -37,7 +37,7 @@ export default (node: HTMLElement) => {
   const isSubscriber = ['gudok_m', 'gudok_w'].some((type) => iconType?.contains(type))
   const subscriberDisplayCond = isSubscriber && personaconDisplayMap[ID_PERSONACON_SUBSCRIPTION]
 
-  const isNeedRemoved = [
+  const isNeedRemove = [
     bjDisplayCond,
     managerDisplayCond,
     fanDisplayCond,
@@ -46,9 +46,10 @@ export default (node: HTMLElement) => {
     subscriberDisplayCond,
   ].every((cond) => !cond)
 
-  if (!isNeedRemoved) {
+  if (!isNeedRemove) {
     return
   }
+  
   const personacon = node.querySelector('em')
   if (!personacon) {
     return

--- a/src/lib/display-personacon.ts
+++ b/src/lib/display-personacon.ts
@@ -19,7 +19,6 @@ CHAT_LAYER_SET_DISPLAY_PERSONACON_MESSAGES.forEach((message) => {
 export default (node: HTMLElement) => {
   // iconType은 dt의 classList지만, 아프리카TV에서는 이 정보를 표시할 퍼스나콘 타입을 정의하는데 사용 하고 있음
   const iconType = node.querySelector('dt')?.classList
-  const personacon = node.querySelector('em')
   const isBj = ['man', 'woman'].some((type) => iconType?.contains(type))
   const bjDisplayCond = isBj && personaconDisplayMap[ID_PERSONACON_BJ]
 
@@ -38,7 +37,7 @@ export default (node: HTMLElement) => {
   const isSubscriber = ['gudok_m', 'gudok_w'].some((type) => iconType?.contains(type))
   const subscriberDisplayCond = isSubscriber && personaconDisplayMap[ID_PERSONACON_SUBSCRIPTION]
 
-  const isRemove = [
+  const isRemoved = [
     bjDisplayCond,
     managerDisplayCond,
     fanDisplayCond,
@@ -47,11 +46,16 @@ export default (node: HTMLElement) => {
     subscriberDisplayCond,
   ].every((cond) => !cond)
 
-  if (!isRemove) {
+  if (!isRemoved) {
     return
   }
-  personacon?.remove()
-  // // 채팅 섹션은 성별 아이콘을 표시하기 위해 왼쪽 패딩을 사용하는데, 이를 제거하기 위한 코드
+  const personacon = node.querySelector('em')
+  if (!personacon) {
+    return
+  }
+  personacon.remove()
+
+  // 퍼스나콘은 성별 아이콘을 표시하기 위해, 챗 영역은 퍼스나콘 만큼 공간 확보를 위해 왼쪽 패딩을 사용하는데, 이를 제거하기 위한 코드
   node.childNodes.forEach((child) => {
     if (!(child instanceof HTMLElement)) {
       return

--- a/src/lib/display-personacon.ts
+++ b/src/lib/display-personacon.ts
@@ -37,7 +37,7 @@ export default (node: HTMLElement) => {
   const isSubscriber = ['gudok_m', 'gudok_w'].some((type) => iconType?.contains(type))
   const subscriberDisplayCond = isSubscriber && personaconDisplayMap[ID_PERSONACON_SUBSCRIPTION]
 
-  const isRemoved = [
+  const isNeedRemoved = [
     bjDisplayCond,
     managerDisplayCond,
     fanDisplayCond,
@@ -46,7 +46,7 @@ export default (node: HTMLElement) => {
     subscriberDisplayCond,
   ].every((cond) => !cond)
 
-  if (!isRemoved) {
+  if (!isNeedRemoved) {
     return
   }
   const personacon = node.querySelector('em')


### PR DESCRIPTION
## Feature Description

- fix(chat): 퍼스나콘 사용 시 채팅 사이에 공백이 생기는 문제

## Solution Description

- `manifest.json`: version 1.1.6 -> 1.1.7
- `chat-one-line.ts`: Apply left padding 0 if chat displayed one line
- `display-personacon.ts`: rename `isRemove` -> `isNeedRemove`

## Types of changes

- [x] Bug fix